### PR TITLE
Addded default value setting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,6 @@
   },
   "peerDependencies": {
     "svelte": "^5.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/schema.json
+++ b/schema.json
@@ -64,6 +64,12 @@
           "setting": "previewSize",
           "value": "custom"
         }
+      },
+      {
+        "type": "text",
+        "label": "Default value",
+        "key": "defaultValue",
+        "placeholder": "#000000"
       }
     ]
   }

--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -60,7 +60,11 @@
   });
 </script>
 
-<div class="spectrum-Form-item" use:styleable={$component.styles}>
+<div
+  class="spectrum-Form-item"
+  class:above-label={labelPos === "above"}
+  use:styleable={$component.styles}
+>
   {#if !formContext}
     <div class="placeholder">Form components need to be wrapped in a form</div>
   {:else}
@@ -106,6 +110,10 @@
 </div>
 
 <style>
+  .spectrum-Form-item.above-label {
+    display: flex;
+    flex-direction: column;
+  }
   .placeholder {
     color: var(--spectrum-global-color-gray-600);
   }

--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -1,9 +1,10 @@
 <script>
-  import { getContext, onDestroy, onMount } from "svelte";
+  import { getContext, onDestroy } from "svelte";
   import { ColorPicker, Color } from "svelte-colorpick";
 
   export let field;
   export let label;
+  export let defaultValue;
 
   export let customPreviewSize;
   export let previewSize;
@@ -35,7 +36,7 @@
   $: formField = formApi?.registerField(
     field,
     "text",
-    "#000000",
+    defaultValue || "#000000",
     false,
     null,
     formStep
@@ -49,9 +50,9 @@
   $: labelClass =
     labelPos === "above" ? "" : `spectrum-FieldLabel--${labelPos}`;
 
-  onMount(() => {
-    color = Color.hex(fieldState?.value);
-  });
+  $: if (fieldState?.value && !color) {
+    color = Color.hex(fieldState.value);
+  }
 
   onDestroy(() => {
     fieldApi?.deregister();


### PR DESCRIPTION
## What
1. Added support for setting a default color value.
2. Updated the color picker label styling to match other Budibase components.

## Why
1. Without an initial value, previously selected colors could reset to black when other properties in the same object (form submission) were updated. This change preserves the existing color value and avoids requiring users to select it again.
2. The label styling fix also improves consistency across the UI.

## Testing
The new build performs as expected in my budibase project. Automated regression tests were not available in the respository and were not performed.
